### PR TITLE
Fix docker machine create vm with fixed ip needs dhcp enabled

### DIFF
--- a/profitbricks.go
+++ b/profitbricks.go
@@ -312,7 +312,7 @@ func (d *Driver) Create() error {
 			Name: d.MachineName,
 			Lan:  lanId,
 			Ips:  ipblockresp.Properties.Ips,
-			Dhcp:	true,
+			Dhcp: true,
 		},
 	}
 

--- a/profitbricks.go
+++ b/profitbricks.go
@@ -312,6 +312,7 @@ func (d *Driver) Create() error {
 			Name: d.MachineName,
 			Lan:  lanId,
 			Ips:  ipblockresp.Properties.Ips,
+			Dhcp:	true,
 		},
 	}
 


### PR DESCRIPTION
This changes enables the profitbricks docker-machine driver to successfully connect to the newly created vm to configure it for its purpose running Docker on it:

Currently when the profitbricks docker-machine driver creates a new vm, it reserves a single fixed IP and assigns it to the newly created vm. But currently the guest os in the vm will not get notice of the network configuration other than by having DHCP enabled for the vm. With vm DHCP enabled the guest os nic is automatically assigned the fixed ip. Having the guest os nic setup with the fixed ip, docker-machine is connecting to that vm and then doing all the Docker setup via ssh.