### PR TITLE
:hammer: resolve identical node and volume name conflict #36

### DIFF
--- a/profitbricks.go
+++ b/profitbricks.go
@@ -295,7 +295,7 @@ func (d *Driver) Create() error {
 						Properties: profitbricks.VolumeProperties{
 							Type:             d.DiskType,
 							Size:             d.DiskSize,
-							Name:             d.MachineName,
+							Name:             fmt.Sprintf("%s-disk", d.MachineName),
 							Image:            image,
 							ImageAlias:       alias,
 							SshKeys:          []string{d.SSHKey},
@@ -503,12 +503,12 @@ func (d *Driver) GetState() (state.State, error) {
 	d.setPB()
 	server := profitbricks.GetServer(d.DatacenterId, d.ServerId)
 
-	if server.StatusCode > 299{
+	if server.StatusCode > 299 {
 
-		if server.StatusCode == 401{
+		if server.StatusCode == 401 {
 			return state.None, fmt.Errorf("Unauthorized. Either user name or password are incorrect.")
 
-		}		else {
+		} else {
 			return state.None, fmt.Errorf("Error occurred while fetching a server: %s", server.Response)
 		}
 	}


### PR DESCRIPTION
When creating a new node the volume is named identical to the node name. This causes an warning in the DCD. So I'd assume to add a suffix to the volume name when creating the server.

